### PR TITLE
Prefixes are applied in reverse order

### DIFF
--- a/agdatex.py
+++ b/agdatex.py
@@ -126,7 +126,7 @@ for src_path, tgt_path in zip(src_paths, tgt_paths):
     stop_command_on_empty_line = False
     def start_command(name, is_inline):
         global mode, tgt, prefixes
-        for p in prefixes:
+        for p in reversed(prefixes):
             name = p + name
         commands.append(name)
         if mode == "hide":


### PR DESCRIPTION
Prefixes are accumulated on a stack, but they are applied in order from oldest to newest. That is, if we open prefixes X, then Y and define name N, the generated output is YXN, but it should be XYN. This patch inserts  when iterating over prefixes.
