### PR TITLE
Every run compiles all files

### DIFF
--- a/agdatex.py
+++ b/agdatex.py
@@ -41,6 +41,9 @@ ap.add_argument("-v", "--verbose", action='store_true',
 ap.add_argument("-n", "--noop", action='store_true',
                     help="No action: dry run")
 
+ap.add_argument ("-c", "--clear", action='store_true',
+                     help="Clear cashes to force rebuild all")
+
 ap.add_argument("sources", metavar="SRC_PATH", nargs="+",
                 help="Path to an annotated .agda-file.")
 
@@ -98,12 +101,15 @@ if args.verbose:
     print (f"VERBOSE: tmp_root = {tmp_root}")
 
 old_hashes = dict()
-try:
-    with open(".agdatex-hashes.json") as digest:
-        old_hashes = json.load(digest)
-except (OSError, json.decoder.JSONDecodeError):
-    if args.verbose:
-        print (f"VERBOSE: cannot read hashes")
+if arg.clear:
+    printf (f"VERBOSE: ignoring cached hashes")
+else:
+    try:
+        with open(".agdatex-hashes.json") as digest:
+            old_hashes = json.load(digest)
+    except (OSError, json.decoder.JSONDecodeError) as e:
+        if args.verbose:
+            print (f"VERBOSE: cannot read hashes ({e})")
 
 if args.verbose:
     print(f"VERBOSE: {old_hashes=}")

--- a/agdatex.py
+++ b/agdatex.py
@@ -101,7 +101,7 @@ if args.verbose:
     print (f"VERBOSE: tmp_root = {tmp_root}")
 
 old_hashes = dict()
-if arg.clear:
+if args.clear:
     printf (f"VERBOSE: ignoring cached hashes")
 else:
     try:

--- a/agdatex.py
+++ b/agdatex.py
@@ -298,7 +298,7 @@ else:
 src_names = [ p.stem for p in src_paths ]
 s = ""
 if export_file.suffix == ".sty":
-    s += "\ProvidesPackage{" + export_file.stem + "}\n"
+    s += "\\ProvidesPackage{" + export_file.stem + "}\n"
 for p in output_dir.glob("**/*.tex"):
     if p.stem in src_names:
         s += "\\input{" + str(p.relative_to(output_dir)) + "}\n"


### PR DESCRIPTION
This patch hashes all input files and compiles only those files that have changed since the last run of agdatex.