### PR TITLE
Full filenames in agda-generated

### DIFF
--- a/agdatex.py
+++ b/agdatex.py
@@ -23,6 +23,9 @@ ap.add_argument("-o", "--outputdir", metavar="PATH", default="latex",
 ap.add_argument("-e", "--exportfile", metavar="PATH",
                 help="This file will \\input all generated .tex files. Both .tex and .sty are supported. Default: 'OUTPUTDIR/agda-generated.sty'.")
 
+ap.add_argument("-f", "--fullpath", action='store_true',
+                    help="Write full path to the generated .tex files into the exportfile.")
+
 ap.add_argument("-t", "--tempdir", metavar="PATH",
                 help="Temporary directory to copy the project root to. Default: fresh system-dependent temporary dir.")
 
@@ -301,7 +304,10 @@ if export_file.suffix == ".sty":
     s += "\\ProvidesPackage{" + export_file.stem + "}\n"
 for p in output_dir.glob("**/*.tex"):
     if p.stem in src_names:
-        s += "\\input{" + str(p.relative_to(output_dir)) + "}\n"
+        if args.fullpath:
+            s += "\\input{" + str(p) + "}\n"
+        else:
+            s += "\\input{" + str(p.relative_to(output_dir)) + "}\n"
 with open(export_file, 'w') as f:
     f.write(s)
 

--- a/agdatex.py
+++ b/agdatex.py
@@ -36,13 +36,13 @@ ap.add_argument("-i", "--index", metavar="PATH",
                 help="Write the list of generated macros to this file.")
 
 ap.add_argument("-v", "--verbose", action='store_true',
-                     help="Turn on verbosity")
+                    help="Turn on verbosity")
 
 ap.add_argument("-n", "--noop", action='store_true',
                     help="No action: dry run")
 
-ap.add_argument ("-c", "--clear", action='store_true',
-                     help="Clear cashes to force rebuild all")
+ap.add_argument("-c", "--clear", action='store_true',
+                    help="Clear cashes to force rebuild all")
 
 ap.add_argument("sources", metavar="SRC_PATH", nargs="+",
                 help="Path to an annotated .agda-file.")


### PR DESCRIPTION
Normally, the `agda-generated` file is put into the `latex` directory and the main file uses
`\input{latex/agda-generated}` to pull it in.
Unfortunately, the generated `\input`s do not have the `latex` prefix so we need to add that to
the `TEXINPUTS` path.

This PR implements an option `--fullpath` that puts the full path of the generated files
into `agda-generated`.

