### PR TITLE
Give users control over `AgdaAlign` placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,38 @@ The following comment annotations are supported:
 
 -   `--! ]` stops hiding code inside of a command.
 
+## Alignment between multiple code blocks
+
+The code typeset by a single extracted macro is wrapped in an `AgdaAlign`
+environment. This is necessary to ensure proper alignment if segments inside a
+single macro are hidden using `--! [` and `--! ]`.
+
+But to align code from multiple macros a surrounding `AgdaAlign` environment is
+required. `AgdaAlign` environments, however, (or similar environments, such as
+`AgdaMultiCode`) may not be nested. Instead, use the starred version of the
+extracted macro `\Foo*` which _does not_ wrap the code in
+`AgdaAlign`/`AgdaSuppressSpace` but makes this your reponsibility.
+
+```latex
+\begin{AgdaAlign}
+\FunctionPartI*
+... explanation/intermediate prose ...
+\FunctionPartII*
+\end{AgdaAlign}
+```
+
+In some cases the starred version may also provide a workaround for [`! Package
+array Error: Empty preamble: 'l' used.`][issue 7290]. If LaTeX emits this error
+for a macro which does not require an explicit `AgdaAlign` environment (ie. no
+`--! [` and `--! ]`) you can try using the starred version of the macro.
+
+For further information regarding [alignment][] and [multiple code blocks][]
+please refer to the Agda documentation.
+
+[alignment]: https://agda.readthedocs.io/en/stable/tools/generating-latex.html#alignment
+[multiple code blocks]: https://agda.readthedocs.io/en/stable/tools/generating-latex.html#breaking-up-code-blocks
+[issue 7290]: https://github.com/agda/agda/issues/7290
+
 ## Usage
 
 Let's say you have a project structure like

--- a/agdatex.py
+++ b/agdatex.py
@@ -150,7 +150,7 @@ for src_path, tgt_path in zip(src_paths, tgt_paths):
     with open(tmp_root / src_path, 'r') as f:
         src = f.read();
 
-    tgt = ""
+    tgt = "\\usepackage{xparse}\n\n"
     prefixes = []
     mode = "none"
     stop_command_on_empty_line = False
@@ -166,15 +166,13 @@ for src_path, tgt_path in zip(src_paths, tgt_paths):
             print(f"ERROR: Line {line_num+1} starts a nested command:\n  {line}")
         mode = "command"
         opt = "[inline]" if is_inline else ""
-        tgt += "\\newcommand*\\" + name + "{"
-        tgt += "\\begin{AgdaAlign}"
-        tgt += "\\begin{AgdaSuppressSpace}"
+        tgt += "\\NewDocumentCommand\\" + name + "{s}{"
+        tgt += "\\IfBooleanF{#1}{\\begin{AgdaAlign}\\begin{AgdaSuppressSpace}}\n"
         tgt += "\\begin{code}" + opt + "\n"
     def stop_command():
         global mode, tgt, prefixes
-        tgt += "\\end{code}"
-        tgt += "\\end{AgdaSuppressSpace}"
-        tgt += "\\end{AgdaAlign}"
+        tgt += "\\end{code}\n"
+        tgt += "\\IfBooleanF{#1}{\\end{AgdaSuppressSpace}\\end{AgdaAlign}}"
         tgt += "}\n"
         mode = "none"
     def latexname(name: str) -> bool:

--- a/example/Makefile
+++ b/example/Makefile
@@ -8,7 +8,7 @@ EXTRA_FILES=$(wildcard *.bib *.cls *.sty *.tex)
 SRCS=$(wildcard $(SRC_DIR)/*.agda)
 TGTS=$(patsubst $(SRC_DIR)/%.agda,$(CACHE_DIR)/$(SRC_DIR)/%.tex,$(SRCS))
 
-.PHONY: all paper
+.PHONY: all paper fast
 
 all: paper
 
@@ -20,11 +20,11 @@ paper: $(FAST_PDF)
 	cd $(CACHE_DIR); bibtex main; pdflatex main.tex; pdflatex main.tex
 	cp $(CACHE_DIR)/main.pdf $(MAIN_PDF)
 
-$(FAST_PDF): $(TGTS) $(MAIN_TEX)
+$(FAST_PDF): $(TGTS) $(MAIN_TEX) $(EXTRA_FILES)
 	cp $(MAIN_TEX) $(CACHE_DIR)/main.tex
 	cp -f $(EXTRA_FILES) $(CACHE_DIR)/
 	cd $(CACHE_DIR); pdflatex main.tex
 	cp $(CACHE_DIR)/main.pdf $(FAST_PDF)
 
-$(TGTS): $(SRCS)
+$(TGTS): ../agdatex.py $(SRCS)
 	../agdatex.py -r . -o $(CACHE_DIR) $(SRCS)

--- a/example/STLC/Syntax.agda
+++ b/example/STLC/Syntax.agda
@@ -31,3 +31,14 @@ missing =
 --! ]
   · (` 1)
 --! }
+
+--! SizeI {
+size : ℕ
+size (` x)   = 1
+--! }
+--! SizeII {
+size (λx M)  = 1 + size M
+--! }
+--! SizeIII {
+size (M · N) = 1 + size M + size N
+--! }

--- a/example/paper.tex
+++ b/example/paper.tex
@@ -14,4 +14,15 @@
 
   In the following code something is missing:
   \STLCHideExample
+
+  This shows how we can align code from multiple macros with intermediate
+  prose.
+  \begin{AgdaAlign}
+    \STLCSizeI*
+    Explain what we do in this case \dots
+    \STLCSizeII*
+    \dots and some more explanation here
+    \STLCSizeIII*
+    \dots and look at the nicely aligned equals signs!
+  \end{AgdaAlign}
 \end{document}


### PR DESCRIPTION
Usages such as this are not supported at the moment because `AgdaAlign` environments may not be nested:

```latex
\begin{AgdaAlign}
\FunctionPartI
... explanation/intermediate prose ...
\FunctionPartII
\end{AgdaAlign}
```

With the proposed changes every macro exists in a starred form as well which makes it the user's responsibility to wrap with an `AgdaAlign` if necessary. The above example could then be written as

```latex
\begin{AgdaAlign}
\FunctionPartI*
... explanation/intermediate prose ...
\FunctionPartII*
\end{AgdaAlign}
```